### PR TITLE
Fix data race when running `go-git` tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,18 +1,19 @@
 on: [push, pull_request]
 name: Test
+permissions: {}
 jobs:
   test:
     strategy:
       matrix:
-        go-version: [1.14.x, 1.15.x, 1.16.x]
+        go-version: [1.18.x,1.19.x]
         platform: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.platform }}
     steps:
     - name: Install Go
-      uses: actions/setup-go@v1
+      uses: actions/setup-go@v3
       with:
         go-version: ${{ matrix.go-version }}
     - name: Checkout code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
     - name: Test
-      run: go test ./...
+      run: make test

--- a/.github/workflows/test_js.yml
+++ b/.github/workflows/test_js.yml
@@ -1,24 +1,25 @@
 on: [push, pull_request]
-name: Test
+name: Test JS
+permissions: {}
 jobs:
   test:
     strategy:
       matrix:
-        go-version: [1.14.x, 1.15.x, 1.16.x]
+        go-version: [1.18.x,1.19.x]
     runs-on: ubuntu-latest
     steps:
     - name: Install Go
-      uses: actions/setup-go@v1
+      uses: actions/setup-go@v3
       with:
         go-version: ${{ matrix.go-version }}
 
     - name: Install wasmbrowsertest
       run: |
-        go get github.com/agnivade/wasmbrowsertest
+        go install github.com/agnivade/wasmbrowsertest@latest
         mv $HOME/go/bin/wasmbrowsertest $HOME/go/bin/go_js_wasm_exec
 
     - name: Checkout code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     - name: Test
       run: go test -exec="$HOME/go/bin/go_js_wasm_exec" ./...

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,11 @@
+# Go parameters
+GOCMD = go
+GOTEST = $(GOCMD) test 
+
+.PHONY: test
+test:
+	$(GOTEST) -race ./...
+
+test-coverage:
+	echo "" > $(COVERAGE_REPORT); \
+	$(GOTEST) -coverprofile=$(COVERAGE_REPORT) -coverpkg=./... -covermode=$(COVERAGE_MODE) ./...

--- a/go.mod
+++ b/go.mod
@@ -3,8 +3,8 @@ module github.com/go-git/go-billy/v5
 require (
 	github.com/kr/text v0.2.0 // indirect
 	github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e // indirect
-	golang.org/x/sys v0.0.0-20200302150141-5c8b2ff67527
-	gopkg.in/check.v1 v1.0.0-20200227125254-8fa46927fb4f
+	golang.org/x/sys v0.3.0
+	gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c
 )
 
 go 1.13

--- a/go.sum
+++ b/go.sum
@@ -1,6 +1,8 @@
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/go-git/go-billy v1.0.0 h1:bXR6Zu3opPSg0R4dDxqaLglY4rxw7ja7wS16qSpOKL4=
 github.com/go-git/go-billy v3.1.0+incompatible h1:dwrJ8G2Jt1srYgIJs+lRjA36qBY68O2Lg5idKG8ef5M=
+github.com/kr/pretty v0.2.1 h1:Fmg33tUaq4/8ym9TJN1x7sLJnHVwhP33CNkpYV/7rwI=
+github.com/kr/pretty v0.2.1/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
@@ -10,5 +12,11 @@ github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e h1:fD57ERR4JtEqsWb
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
 golang.org/x/sys v0.0.0-20200302150141-5c8b2ff67527 h1:uYVVQ9WP/Ds2ROhcaGPeIdVq0RIXVLwsHlnvJ+cT1So=
 golang.org/x/sys v0.0.0-20200302150141-5c8b2ff67527/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.2.0 h1:ljd4t30dBnAvMZaQCevtY0xLLD0A+bRZXbgLMLU1F/A=
+golang.org/x/sys v0.2.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.3.0 h1:w8ZOecv6NaNa/zC8944JTU3vz4u6Lagfk4RPQxv92NQ=
+golang.org/x/sys v0.3.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 gopkg.in/check.v1 v1.0.0-20200227125254-8fa46927fb4f h1:BLraFXnmrev5lT+xlilqcH8XK9/i0At2xKjWk4p6zsU=
 gopkg.in/check.v1 v1.0.0-20200227125254-8fa46927fb4f/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c h1:Hei/4ADfdWqJk1ZMxUNpqntNwaWcugrBjAiHlqqRiVk=
+gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c/go.mod h1:JHkPIbrfpd72SG/EVd6muEfDQjcINNoR0C8j2r3qZ4Q=

--- a/util/walk_test.go
+++ b/util/walk_test.go
@@ -20,6 +20,7 @@ type WalkSuite struct{}
 func TestWalk(t *testing.T) { TestingT(t) }
 
 var _ = Suite(&WalkSuite{})
+var targetSubfolder = filepath.FromSlash("path/to/some/subfolder")
 
 func (s *WalkSuite) TestWalkCanSkipTopDirectory(c *C) {
 	filesystem := memfs.New()
@@ -52,13 +53,13 @@ func (s *WalkSuite) TestWalkOnExistingFolder(c *C) {
 		return nil
 	}), IsNil)
 	c.Assert(discoveredPaths, Contains, "path")
-	c.Assert(discoveredPaths, Contains, "path/to")
-	c.Assert(discoveredPaths, Contains, "path/to/some")
-	c.Assert(discoveredPaths, Contains, "path/to/some/file")
-	c.Assert(discoveredPaths, Contains, "path/to/some/subfolder")
-	c.Assert(discoveredPaths, Contains, "path/to/some/subfolder/that")
-	c.Assert(discoveredPaths, Contains, "path/to/some/subfolder/that/contain")
-	c.Assert(discoveredPaths, Contains, "path/to/some/subfolder/that/contain/file")
+	c.Assert(discoveredPaths, Contains, filepath.FromSlash("path/to"))
+	c.Assert(discoveredPaths, Contains, filepath.FromSlash("path/to/some"))
+	c.Assert(discoveredPaths, Contains, filepath.FromSlash("path/to/some/file"))
+	c.Assert(discoveredPaths, Contains, filepath.FromSlash("path/to/some/subfolder"))
+	c.Assert(discoveredPaths, Contains, filepath.FromSlash("path/to/some/subfolder/that"))
+	c.Assert(discoveredPaths, Contains, filepath.FromSlash("path/to/some/subfolder/that/contain"))
+	c.Assert(discoveredPaths, Contains, filepath.FromSlash("path/to/some/subfolder/that/contain/file"))
 }
 
 func (s *WalkSuite) TestWalkCanSkipFolder(c *C) {
@@ -68,19 +69,19 @@ func (s *WalkSuite) TestWalkCanSkipFolder(c *C) {
 	discoveredPaths := []string{}
 	c.Assert(util.Walk(filesystem, "path", func(path string, info os.FileInfo, err error) error {
 		discoveredPaths = append(discoveredPaths, path)
-		if path == "path/to/some/subfolder" {
+		if path == targetSubfolder {
 			return filepath.SkipDir
 		}
 		return nil
 	}), IsNil)
 	c.Assert(discoveredPaths, Contains, "path")
-	c.Assert(discoveredPaths, Contains, "path/to")
-	c.Assert(discoveredPaths, Contains, "path/to/some")
-	c.Assert(discoveredPaths, Contains, "path/to/some/file")
-	c.Assert(discoveredPaths, Contains, "path/to/some/subfolder")
-	c.Assert(discoveredPaths, NotContain, "path/to/some/subfolder/that")
-	c.Assert(discoveredPaths, NotContain, "path/to/some/subfolder/that/contain")
-	c.Assert(discoveredPaths, NotContain, "path/to/some/subfolder/that/contain/file")
+	c.Assert(discoveredPaths, Contains, filepath.FromSlash("path/to"))
+	c.Assert(discoveredPaths, Contains, filepath.FromSlash("path/to/some"))
+	c.Assert(discoveredPaths, Contains, filepath.FromSlash("path/to/some/file"))
+	c.Assert(discoveredPaths, Contains, filepath.FromSlash("path/to/some/subfolder"))
+	c.Assert(discoveredPaths, NotContain, filepath.FromSlash("path/to/some/subfolder/that"))
+	c.Assert(discoveredPaths, NotContain, filepath.FromSlash("path/to/some/subfolder/that/contain"))
+	c.Assert(discoveredPaths, NotContain, filepath.FromSlash("path/to/some/subfolder/that/contain/file"))
 }
 
 func (s *WalkSuite) TestWalkStopsOnError(c *C) {
@@ -90,19 +91,19 @@ func (s *WalkSuite) TestWalkStopsOnError(c *C) {
 	discoveredPaths := []string{}
 	c.Assert(util.Walk(filesystem, "path", func(path string, info os.FileInfo, err error) error {
 		discoveredPaths = append(discoveredPaths, path)
-		if path == "path/to/some/subfolder" {
+		if path == targetSubfolder {
 			return errors.New("uncaught error")
 		}
 		return nil
 	}), NotNil)
 	c.Assert(discoveredPaths, Contains, "path")
-	c.Assert(discoveredPaths, Contains, "path/to")
-	c.Assert(discoveredPaths, Contains, "path/to/some")
-	c.Assert(discoveredPaths, Contains, "path/to/some/file")
-	c.Assert(discoveredPaths, Contains, "path/to/some/subfolder")
-	c.Assert(discoveredPaths, NotContain, "path/to/some/subfolder/that")
-	c.Assert(discoveredPaths, NotContain, "path/to/some/subfolder/that/contain")
-	c.Assert(discoveredPaths, NotContain, "path/to/some/subfolder/that/contain/file")
+	c.Assert(discoveredPaths, Contains, filepath.FromSlash("path/to"))
+	c.Assert(discoveredPaths, Contains, filepath.FromSlash("path/to/some"))
+	c.Assert(discoveredPaths, Contains, filepath.FromSlash("path/to/some/file"))
+	c.Assert(discoveredPaths, Contains, filepath.FromSlash("path/to/some/subfolder"))
+	c.Assert(discoveredPaths, NotContain, filepath.FromSlash("path/to/some/subfolder/that"))
+	c.Assert(discoveredPaths, NotContain, filepath.FromSlash("path/to/some/subfolder/that/contain"))
+	c.Assert(discoveredPaths, NotContain, filepath.FromSlash("path/to/some/subfolder/that/contain/file"))
 }
 
 func (s *WalkSuite) TestWalkForwardsStatErrors(c *C) {
@@ -110,7 +111,7 @@ func (s *WalkSuite) TestWalkForwardsStatErrors(c *C) {
 	filesystem := &fnFs{
 		Filesystem: memFilesystem,
 		lstat: func(path string) (os.FileInfo, error) {
-			if path == "path/to/some/subfolder" {
+			if path == targetSubfolder {
 				return nil, errors.New("uncaught error")
 			}
 			return memFilesystem.Lstat(path)
@@ -122,19 +123,19 @@ func (s *WalkSuite) TestWalkForwardsStatErrors(c *C) {
 	discoveredPaths := []string{}
 	c.Assert(util.Walk(filesystem, "path", func(path string, info os.FileInfo, err error) error {
 		discoveredPaths = append(discoveredPaths, path)
-		if path == "path/to/some/subfolder" {
+		if path == targetSubfolder {
 			c.Assert(err, NotNil)
 		}
 		return err
 	}), NotNil)
 	c.Assert(discoveredPaths, Contains, "path")
-	c.Assert(discoveredPaths, Contains, "path/to")
-	c.Assert(discoveredPaths, Contains, "path/to/some")
-	c.Assert(discoveredPaths, Contains, "path/to/some/file")
-	c.Assert(discoveredPaths, Contains, "path/to/some/subfolder")
-	c.Assert(discoveredPaths, NotContain, "path/to/some/subfolder/that")
-	c.Assert(discoveredPaths, NotContain, "path/to/some/subfolder/that/contain")
-	c.Assert(discoveredPaths, NotContain, "path/to/some/subfolder/that/contain/file")
+	c.Assert(discoveredPaths, Contains, filepath.FromSlash("path/to"))
+	c.Assert(discoveredPaths, Contains, filepath.FromSlash("path/to/some"))
+	c.Assert(discoveredPaths, Contains, filepath.FromSlash("path/to/some/file"))
+	c.Assert(discoveredPaths, Contains, filepath.FromSlash("path/to/some/subfolder"))
+	c.Assert(discoveredPaths, NotContain, filepath.FromSlash("path/to/some/subfolder/that"))
+	c.Assert(discoveredPaths, NotContain, filepath.FromSlash("path/to/some/subfolder/that/contain"))
+	c.Assert(discoveredPaths, NotContain, filepath.FromSlash("path/to/some/subfolder/that/contain/file"))
 }
 
 func createFile(c *C, filesystem billy.Filesystem, path string) {


### PR DESCRIPTION
Apart from the main change highlighted in the title, this PR also:
- build: Update GitHub workflows.
  - Remove unecessary token permissions in CI.
  - Bump Action versions to latest.
  - Bump Go version to match go-git.
- build: Bump dependencies.
- Fixes current broken tests when running on Windows.

The `go-git` performance impact whilst running the Parse benchmarks are subtle:
```
name                                                             old time/op    new time/op    delta
Parse/https://github.com/git-fixtures/root-references.git-16       2.40ms ± 6%    2.37ms ± 1%   ~     (p=0.700 n=3+3)
Parse/https://github.com/git-fixtures/basic.git-16                 1.95ms ± 0%    1.96ms ± 0%   ~     (p=0.200 n=3+3)
Parse/https://github.com/git-fixtures/basic.git#01-16              1.97ms ± 0%    2.01ms ± 1%   ~     (p=0.100 n=3+3)
Parse/https://github.com/git-fixtures/basic.git#02-16              1.94ms ± 0%    2.00ms ± 1%   ~     (p=0.100 n=3+3)
Parse/https://github.com/src-d/go-git.git-16                        391ms ± 2%     402ms ± 1%   ~     (p=0.200 n=3+3)
Parse/https://github.com/git-fixtures/tags.git-16                  65.0µs ± 1%    66.9µs ± 1%   ~     (p=0.100 n=3+3)
Parse/https://github.com/spinnaker/spinnaker.git-16                 104ms ± 0%     110ms ± 2%   ~     (p=0.100 n=3+3)
Parse/https://github.com/jamesob/desk.git-16                       14.1ms ± 2%    14.4ms ± 1%   ~     (p=0.100 n=3+3)
Parse/https://github.com/cpcs499/Final_Pres_P.git-16               18.0µs ± 1%    18.2µs ± 3%   ~     (p=1.000 n=3+3)
Parse/https://github.com/github/gem-builder.git-16                 1.25ms ± 4%    1.22ms ± 1%   ~     (p=0.700 n=3+3)
Parse/https://github.com/githubtraining/example-branches.git-16     257µs ± 2%     258µs ± 1%   ~     (p=1.000 n=3+3)
Parse/https://github.com/rumpkernel/rumprun-xen.git-16              120ms ± 3%     117ms ± 1%   ~     (p=0.400 n=3+3)
Parse/https://github.com/mcuadros/skeetr.git-16                    3.42ms ± 1%    3.44ms ± 2%   ~     (p=1.000 n=3+3)
Parse/https://github.com/dezfowler/LiteMock.git-16                 6.02ms ± 2%    6.07ms ± 1%   ~     (p=0.700 n=3+3)
Parse/https://github.com/tyba/storable.git-16                      18.4ms ± 3%    18.1ms ± 1%   ~     (p=0.700 n=3+3)
Parse/https://github.com/toqueteos/ts3.git-16                      1.74ms ± 1%    1.71ms ± 1%   ~     (p=0.100 n=3+3)
Parse/#00-16                                                        393µs ± 1%     370µs ± 0%   ~     (p=0.100 n=3+3)
Parse/#01-16                                                       2.72ms ± 5%    2.62ms ± 2%   ~     (p=0.200 n=3+3)
ParseBasic-16                                                      2.09ms ± 3%    2.06ms ± 0%   ~     (p=0.200 n=3+3)
Parser-16                                                          9.01ms ± 3%    8.74ms ± 2%   ~     (p=0.100 n=3+3)

name                                                             old alloc/op   new alloc/op   delta
Parse/https://github.com/git-fixtures/root-references.git-16        474kB ± 0%     473kB ± 1%   ~     (p=1.000 n=3+3)
Parse/https://github.com/git-fixtures/basic.git-16                  247kB ± 1%     247kB ± 1%   ~     (p=1.000 n=3+3)
Parse/https://github.com/git-fixtures/basic.git#01-16               245kB ± 1%     246kB ± 1%   ~     (p=0.400 n=3+3)
Parse/https://github.com/git-fixtures/basic.git#02-16               222kB ± 1%     221kB ± 1%   ~     (p=0.400 n=3+3)
Parse/https://github.com/src-d/go-git.git-16                       37.9MB ± 1%    39.9MB ± 5%   ~     (p=0.200 n=3+3)
Parse/https://github.com/git-fixtures/tags.git-16                  87.5kB ± 0%    87.5kB ± 0%   ~     (p=0.700 n=3+3)
Parse/https://github.com/spinnaker/spinnaker.git-16                44.2MB ± 0%    44.3MB ± 0%   ~     (p=0.200 n=3+3)
Parse/https://github.com/jamesob/desk.git-16                       4.59MB ± 0%    4.59MB ± 0%   ~     (p=1.000 n=3+3)
Parse/https://github.com/cpcs499/Final_Pres_P.git-16               16.9kB ± 0%    16.9kB ± 0%   ~     (p=0.600 n=3+3)
Parse/https://github.com/github/gem-builder.git-16                  649kB ± 0%     649kB ± 0%   ~     (p=1.000 n=3+3)
Parse/https://github.com/githubtraining/example-branches.git-16     210kB ± 0%     210kB ± 0%   ~     (p=1.000 n=3+3)
Parse/https://github.com/rumpkernel/rumprun-xen.git-16             33.7MB ± 2%    33.0MB ± 2%   ~     (p=0.400 n=3+3)
Parse/https://github.com/mcuadros/skeetr.git-16                    1.92MB ± 0%    1.92MB ± 0%   ~     (p=1.000 n=3+3)
Parse/https://github.com/dezfowler/LiteMock.git-16                  425kB ± 0%     425kB ± 1%   ~     (p=1.000 n=3+3)
Parse/https://github.com/tyba/storable.git-16                      10.3MB ± 0%    10.2MB ± 0%   ~     (p=0.700 n=3+3)
Parse/https://github.com/toqueteos/ts3.git-16                       777kB ± 0%     777kB ± 0%   ~     (p=0.700 n=3+3)
Parse/#00-16                                                        329kB ± 0%     329kB ± 0%   ~     (p=0.100 n=3+3)
Parse/#01-16                                                       1.01MB ± 0%    1.01MB ± 0%   ~     (p=1.000 n=3+3)
ParseBasic-16                                                       236kB ± 0%     236kB ± 1%   ~     (p=0.700 n=3+3)
Parser-16                                                          2.15MB ± 1%    2.13MB ± 1%   ~     (p=0.400 n=3+3)

name                                                             old allocs/op  new allocs/op  delta
Parse/https://github.com/git-fixtures/root-references.git-16        1.36k ± 0%     1.36k ± 0%   ~     (all equal)
Parse/https://github.com/git-fixtures/basic.git-16                    704 ± 0%       704 ± 0%   ~     (all equal)
Parse/https://github.com/git-fixtures/basic.git#01-16                 688 ± 0%       688 ± 0%   ~     (all equal)
Parse/https://github.com/git-fixtures/basic.git#02-16                 621 ± 0%       620 ± 0%   ~     (p=0.400 n=3+3)
Parse/https://github.com/src-d/go-git.git-16                        78.1k ± 0%     78.1k ± 0%   ~     (p=0.500 n=3+3)
Parse/https://github.com/git-fixtures/tags.git-16                     164 ± 0%       164 ± 0%   ~     (all equal)
Parse/https://github.com/spinnaker/spinnaker.git-16                  115k ± 0%      115k ± 0%   ~     (p=0.100 n=3+3)
Parse/https://github.com/jamesob/desk.git-16                        13.1k ± 0%     13.1k ± 0%   ~     (p=1.000 n=3+3)
Parse/https://github.com/cpcs499/Final_Pres_P.git-16                 63.0 ± 0%      63.0 ± 0%   ~     (all equal)
Parse/https://github.com/github/gem-builder.git-16                  1.86k ± 0%     1.86k ± 0%   ~     (all equal)
Parse/https://github.com/githubtraining/example-branches.git-16       578 ± 0%       578 ± 0%   ~     (all equal)
Parse/https://github.com/rumpkernel/rumprun-xen.git-16              73.8k ± 0%     73.8k ± 0%   ~     (p=0.100 n=3+3)
Parse/https://github.com/mcuadros/skeetr.git-16                     5.77k ± 0%     5.77k ± 0%   ~     (p=1.000 n=3+3)
Parse/https://github.com/dezfowler/LiteMock.git-16                  1.38k ± 0%     1.38k ± 0%   ~     (p=1.000 n=3+3)
Parse/https://github.com/tyba/storable.git-16                       26.2k ± 0%     26.2k ± 0%   ~     (p=0.300 n=3+3)
Parse/https://github.com/toqueteos/ts3.git-16                       2.52k ± 0%     2.52k ± 0%   ~     (all equal)
Parse/#00-16                                                          974 ± 0%       974 ± 0%   ~     (all equal)
Parse/#01-16                                                        3.38k ± 0%     3.38k ± 0%   ~     (p=1.000 n=3+3)
ParseBasic-16                                                         702 ± 0%       702 ± 0%   ~     (all equal)
Parser-16                                                           3.49k ± 0%     3.49k ± 0%   ~     (p=0.300 n=3+3)
```

Same PR as upstream's: https://github.com/go-git/go-billy/pull/28.